### PR TITLE
Added a new column with replicate info to the pairwise distance data

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ git commit -m "Change a specific functionality"
 git push -u origin main
 ```
 
+#### Making a pull request
+```
+git checkout main
+git pull
+# Before you begin making changes, create a new branch
+git checkout -b new-feature-branch
+git add -A
+git commit -m "Detailed commit message describing the changes"
+git push -u origin new-feature-branch
+# Visit github.com to add description, submit, merge the pull request, and delete the remote branch
+# Once finished on github.com, return to local
+git checkout main
+git pull
+git branch -d new-feature-branch
+```
+
 #### Handle merge conflict
 
 ```

--- a/qa/process.py
+++ b/qa/process.py
@@ -1251,6 +1251,15 @@ def pairwise_distances_csv(pdb_traj_path, replicate_info):
     # Calculate pairwise distances for each frame and store them in a DataFrame
     pairwise_distances_df = trajectory_pairwise_distances(frames)
 
+    # Create a new "replicate" column with all zeros
+    pairwise_distances_df.insert(0, "replicate", 0)
+
+    # Use the replicate_info list to populate the "replicate" column
+    row_idx = 0
+    for replicate, frames_count in replicate_info:
+        pairwise_distances_df.loc[row_idx:row_idx+frames_count-1, "replicate"] = replicate
+        row_idx += frames_count
+
     # Get the number of residue pairs (columns in the DataFrame)
     res_pairs_count = len(pairwise_distances_df.columns)
 


### PR DESCRIPTION
Functionality for adding a new column to the CSV `f"{geometry_name}_pairwise_distances.csv"`. The CSV contains a single header line, and each subsequent line contains tabular data for all combinatorial pairwise distances between amino acids. Using the information in the `replicate_info` output, I added a new column to the CSV file that is being generated with the function `pairwise_distances_csv()`. The new column is inserted as the first column in the CSV. The new column contains a number for each row corresponding to the replicate from which the line originated, and the header line also has a new cell called `replicate`. The values for the new column `replicate`, are added in numerical order. For example, if `replicate_info = [(1,100), (2,100), (3,100)]`, then the new column would contain one hundred 1's, followed by one hundred 2's, and then one hundred 3's. All rows except the header, which will say `replicate`, will now have an associated replicate number.