### PR TITLE
File order bug fix in xyz trajectory creation

### DIFF
--- a/qa/process.py
+++ b/qa/process.py
@@ -1122,7 +1122,7 @@ def string_to_list(str_list: List[str]) -> List[List[int]]:
 
 
 
-def simple_xyz_combine():
+def simple_combine_xyz_files():
     """
     Takes all xyz molecular structure files in the current directory
     and combines them to create a single xyz trajectory.
@@ -1132,10 +1132,13 @@ def simple_xyz_combine():
     The output xyz trajectory file will have no additional white space
     and will have each xyz concatenated after the next.
     The output xyz will be called combined.xyz
-
     """
+
     # Get a list of all xyz files in the current directory
     xyz_files = glob.glob("*.xyz")
+
+    # Sort the files based on the numerical part of the filename
+    xyz_files.sort(key=lambda x: int(os.path.splitext(x)[0]))
 
     # Open the output file in write mode
     with open("combined.xyz", "w") as outfile:
@@ -1148,8 +1151,9 @@ def simple_xyz_combine():
 
                 # Write the contents to the output file
                 outfile.write(contents)
+                outfile.write("\n")  # Add a newline to separate each file's contents
 
-    print(f"   > All .xyz files have been combined into combined.xyz")
+    print(f"All .xyz files have been combined into combined.xyz")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the first iteration of simple_xyz_combine(), there was a bug in the order that the xyz files were being added to the trajectory. The structure naming convention and order was important. The xyz files are named 1.xyz, 2.xyz, 3.xyz, ... , 10.xyz, 11.xyz, ... , 20.xyz, 21.xyz. Therefore when the trajectory is created they need to be in the same order. However, without sorting glob will use lexicographic order such as 1.xyz, 10.xyz, 100.xyz, 2.xyz, 20.xyz, 200.xyz